### PR TITLE
Improve text size and fix overlapping legend keys

### DIFF
--- a/visualization/fn_plot_aux_scores.R
+++ b/visualization/fn_plot_aux_scores.R
@@ -219,18 +219,22 @@ fn_plot_aux_scores <- function(fcst_input,
   # Define various themes
   ptheme_l <- ggplot2::theme_bw() + 
     ggplot2::theme(
-      plot.title      = ggplot2::element_text(size = 10),
-      plot.subtitle   = ggplot2::element_text(size = 8),
-      axis.text       = ggplot2::element_text(size = 10),
-      axis.title      = ggplot2::element_text(size = 10),
-      strip.text      = ggplot2::element_text(size = 10),
-      legend.text     = ggplot2::element_text(size = 10),
+      plot.title      = ggplot2::element_text(size = 10, margin = margin(1,0,1,0)),
+      plot.subtitle   = ggplot2::element_text(size = 8, margin = margin(1,0,0,0)),
+      axis.text       = ggplot2::element_text(size = 8),
+      axis.title      = ggplot2::element_text(size = 8, margin = margin(0,0,0,0)),
+      strip.text      = ggplot2::element_text(size = 8),
+      legend.text     = ggplot2::element_text(size = 8),
+      legend.key.spacing.x = unit(1,"lines"),
+      legend.box.spacing   = unit(0,"pt"),
+      legend.margin        = margin(0,0,0,0),
+      legend.box.margin    = margin(0,0,0,0),
       legend.position = "top"
     )
   ptheme_nc <- ggplot2::theme_bw() + 
     ggplot2::theme(
-      axis.text       = ggplot2::element_text(size = 10),
-      axis.title      = ggplot2::element_text(size = 10),
+      axis.text       = ggplot2::element_text(size = 8),
+      axis.title      = ggplot2::element_text(size = 8, margin = margin(0,0,0,0)),
       legend.position = "none"
     )
   

--- a/visualization/fn_plot_helpers.R
+++ b/visualization/fn_plot_helpers.R
@@ -865,15 +865,15 @@ fn_plot_map <- function(verif,
             axis.text                 = ggplot2::element_blank(),
             axis.ticks                = ggplot2::element_blank(),
             axis.title                = ggplot2::element_blank(),
-            plot.title                = ggplot2::element_text(size = 12),
+            plot.title                = ggplot2::element_text(size = 10),
             plot.title.position       = "plot",
             legend.text               = ggplot2::element_text(size = 8),
             plot.subtitle             = ggplot2::element_text(size = 8), 
-            legend.title              = ggplot2::element_text(size = 10),
+            legend.title              = ggplot2::element_text(size = 8),
             legend.position           = "right", 
             legend.key.height         = unit(1.5,"cm"),
             strip.background          = ggplot2::element_rect(fill = "white"),
-            strip.text                = ggplot2::element_text(size = 12)) +
+            strip.text                = ggplot2::element_text(size = 8)) +
       ggplot2::facet_wrap(
         vars(fcst_model),
         ncol = min(num_models,3)) +

--- a/visualization/fn_plot_point_verif.R
+++ b/visualization/fn_plot_point_verif.R
@@ -353,18 +353,22 @@ fn_plot_point_verif <- function(harp_verif_input,
   # Define various themes
   ptheme_l <- ggplot2::theme_bw() + 
     ggplot2::theme(
-      plot.title      = ggplot2::element_text(size = 10),
-      plot.subtitle   = ggplot2::element_text(size = 8),
-      axis.text       = ggplot2::element_text(size = 10),
-      axis.title      = ggplot2::element_text(size = 10),
-      strip.text      = ggplot2::element_text(size = 10),
-      legend.text     = ggplot2::element_text(size = 10),
+      plot.title      = ggplot2::element_text(size = 10, margin = margin(1,0,1,0)),
+      plot.subtitle   = ggplot2::element_text(size = 8, margin = margin(1,0,0,0)),
+      axis.text       = ggplot2::element_text(size = 8),
+      axis.title      = ggplot2::element_text(size = 8, margin = margin(0,0,0,0)),
+      strip.text      = ggplot2::element_text(size = 8),
+      legend.text     = ggplot2::element_text(size = 8),
+      legend.key.spacing.x = unit(1,"lines"),
+      legend.box.spacing   = unit(0,"pt"),
+      legend.margin        = margin(0,0,0,0),
+      legend.box.margin    = margin(0,0,0,0),
       legend.position = "top"
     )
   ptheme_nc <- ggplot2::theme_bw() + 
     ggplot2::theme(
-      axis.text       = ggplot2::element_text(size = 10),
-      axis.title      = ggplot2::element_text(size = 10),
+      axis.text       = ggplot2::element_text(size = 8),
+      axis.title      = ggplot2::element_text(size = 8, margin = margin(0,0,0,0)),
       legend.position = "none"
     )
   


### PR DESCRIPTION
Squashed commit of the following:
commit 40e44ce73f942e8e15fb4aa35f210f0c925f319b
Merge: 718f846 5f22d05
Author: James Fannon <91901684+j-fannon@users.noreply.github.com>
Date:   Fri Feb 7 11:08:19 2025 +0000

    Merge pull request #124 from dmidk/dev

    Improve default text size and margins for plots:

commit 5f22d0518a72fa867e38c5684f0c38e0ee2d81fd
Author: j-fannon <91901684+j-fannon@users.noreply.github.com>
Date:   Fri Feb 7 11:06:35 2025 +0000

    Improve default text size and margins for plots:
    - Include legend.key.spacing to prevent overlapping long names