### PR TITLE
Remove ISL road statins from wind verification: anemos @ 6 m

### DIFF
--- a/verification/fn_station_selection.R
+++ b/verification/fn_station_selection.R
@@ -108,6 +108,7 @@ fn_station_selection <- function(domain_choice = "All_Domains",
     # Add in filtering of French stations, poor-quality Irish and high-altitude UK stations
     stations_param_rmv <- c(3039,3065,3072,3148,3227,3410,
                             3971,3979,
+                            seq(4800,4999,1),
                             6009,6012,
                             seq(7001,7998,1))
   } else if (param == "T2m") {


### PR DESCRIPTION
From Bolli at IMO:
> Most of the stations that have WMO numbers between 4800-4999 are Road Administration stations and they are not WMO legal, i.e. they don't follow the WMO guidelines and the anemometers are usually at 6m height for these stations. They are also located close to roads and often in the windiest of places.

Suggest removing them from wind verification.





