### PR TITLE
Large update due to MLWP work

### DIFF
--- a/config_files/config_det_example.yml
+++ b/config_files/config_det_example.yml
@@ -24,6 +24,7 @@ verif:
   ua_restrict_vh: TRUE                      # For upper air variables, restict forecast-observation data to valid hours 00, 06, 12, 18Z. 
   force_valid_thr: FALSE                    # Set to TRUE if you really want threshold scores over valid times/hours
   lt_split: FALSE                           # Split some auxiliary scores (e.g. scatterplots, freq hist) between short (<=24), long (>24), and all leadtimes 
+  skip_qc: FALSE                            # Skip all quality control checks
   fcst_path: "/path/to/FCTABLE"
   obs_path: "/path/to/OBSTABLE"
   verif_path: "/path/to/rds_output"

--- a/config_files/config_eps_ctrl_example.yml
+++ b/config_files/config_eps_ctrl_example.yml
@@ -24,6 +24,7 @@ verif:
   ua_restrict_vh: TRUE                      # For upper air variables, restict forecast-observation data to valid hours 00, 06, 12, 18Z. 
   force_valid_thr: FALSE                    # Set to TRUE if you really want threshold scores over valid times/hours
   lt_split: FALSE                           # Split some auxiliary scores (e.g. scatterplots, freq hist) between short (<=24), long (>24), and all leadtimes
+  skip_qc: FALSE                            # Skip all quality control checks
   fcst_path: "/path/to/FCTABLE"
   obs_path: "/path/to/OBSTABLE"
   verif_path: "/path/to/rds_output"

--- a/config_files/config_eps_example.yml
+++ b/config_files/config_eps_example.yml
@@ -25,6 +25,7 @@ verif:
   ua_restrict_vh: TRUE                      # For upper air variables, restict forecast-observation data to valid hours 00, 06, 12, 18Z. 
   force_valid_thr: FALSE                    # Set to TRUE if you really want threshold scores over valid times/hours
   lt_split: FALSE                           # Split some auxiliary scores (e.g. scatterplots, freq hist) between short (<=24), long (>24), and all leadtimes
+  skip_qc: FALSE                            # Skip all quality control checks
   fcst_path: "/path/to/FCTABLE"
   obs_path: "/path/to/OBSTABLE"
   verif_path: "/path/to/rds_output"

--- a/docs/2_Config_file.md
+++ b/docs/2_Config_file.md
@@ -21,12 +21,14 @@ Create a configuration file for your project using the structure provided in the
 | verif | ua_restrict_vh | For upper air variables, do you want to restrict to valid hours 00, 06, 12, and 18Z? Either TRUE (default) or FALSE. | ua_restrict_vh: TRUE |
 | verif | force_valid_thr | Set to TRUE if you really want threshold scores over valid times/hours. FALSE is generally sufficient. | force_valid_thr: FALSE |
 | verif | lt_split | Set to TRUE if you want to split the auxiliary scores (e.g. scatterplots) into "short" (<=24) and "long" (>24) leadtime ranges. Results using all leadtimes will always be generated | lt_split: FALSE |
+| verif | skip_qc | Skip all quality control checks on observations and forecasts. Useful for debugging. Default is FALSE i.e. run the quality control checks. | skip_qc: FALSE |
 | verif | fcst_path    | Path to the forecast sqlite tables generated from the vfld. | fcst_path: "/path/to/FCTABLE" |
 | verif | obs_path     | Path to the observation sqlite tables generated from the vobs. | obs_path: "/path/to/OBSTBALE" |
 | verif | verif_path   | A root directory where the rds verification files are stored. For a given project, these rds files will be located in `verif:verif_path`/`verif:project_name`. | verif_path: "/path/to/rds" |
-| verif | model_as_obs | An extra set of options which indicates that you want to use a forecast model analysis as observations. This will read lead time=0 forecasts from the sqlite. An extra set of options are nested from `model_as_obs`, see example and options below | model_as_obs: <br>  model_as_obs_name: X <br>  model_as_obs_path: X <br>  model_as_obs_tmpl: X |
+| verif | model_as_obs | An extra set of options which indicates that you want to use a forecast model analysis as observations. This will read lead time=0 forecasts from the sqlite. An extra set of options are nested from `model_as_obs`, see example and options below | model_as_obs: <br>  model_as_obs_name: X <br>  model_as_obs_path: X <br>  model_as_obs_by: X <br>  model_as_obs_tmpl: X |
 | verif$model_as_obs | model_as_obs_name | The name of the forecast model to read as observations | model_as_obs_name: model_A |
 | verif$model_as_obs | model_as_obs_path | The path to the forecast database to read as observations | model_as_obs_path: "/path/to/FCTABLE" |
+| verif$model_as_obs | model_as_obs_by | The frequency interval to read the forecast database. Defaults to "1h". Not all analysis files are required to exist. | model_as_obs_by: "3h" |
 | verif$model_as_obs | model_as_obs_tmpl | The file template to use for the forcast database to read as observations | model_as_obs_tmpl: "fctable" | 
 | pre   | fcst_model   | Carry out the vfld to sqlite conversion for these forecast models. Note that this can differ from `verif:fcst_model` (e.g. the sqlite tables may already exist for some models, and you may want to skip regenerating these). | fcst_model: <br> - model_A  <br> - model_B | 
 | pre   | lead_time    | Which lead times to use when converting the vfld. Can differ from `verif:lead_time`. | lead_time: seq(0,48,1) |
@@ -61,3 +63,19 @@ Create a configuration file for your project using the structure provided in the
 | scorecards | parallel    | Use parallel processing when performing the bootstrapping. | parallel: FALSE | 
 | scorecards | num_cores   | Number of cores to use if `parallel=TRUE`. | num_cores: 1 |
 | scorecards | plot_signif | As well as the scorecard, plot the actual score difference as a function of leadtime for each parameter and score (provided that `scorecards:create_scrd` is TRUE). Statistical significance of the score difference is also indicated. Uses `fn_plot_signif_diff.R`. | plot_signif: TRUE | 
+
+## Avoiding config file duplication!
+
+These config files can obviously get quite long given the large number of options available (both required and optional). Frequently you will just want to change one or two options in a configuration file, and as such duplication of all of the other options is a pain. A convenient way of handling this is to use an "experiment" config file, just containing the options you want to change, which references a "base" config file which contains all of the options. If an option is not defined in your "experiment" config file, it will be inherited from the value set in the "base" config file. You can do this by using the `inherits` option as below:
+
+```
+$ cat experiment_config.yml
+inherits: "base_config.yml"
+verif:
+  project_name: "new_project_name"
+  fcst_model:
+    - old_model
+    - new_model
+```
+
+Note that the config file pointed to by `inherits` should exist in directory `config_files`.

--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -102,12 +102,14 @@ Create a configuration file for your project using the structure provided in the
 | verif | ua_restrict_vh | For upper air variables, do you want to restrict to valid hours 00, 06, 12, and 18Z? Either TRUE (default) or FALSE. | ua_restrict_vh: TRUE |
 | verif | force_valid_thr | Set to TRUE if you really want threshold scores over valid times/hours. FALSE is generally sufficient. | force_valid_thr: FALSE |
 | verif | lt_split | Set to TRUE if you want to split the auxiliary scores (e.g. scatterplots) into "short" (<=24) and "long" (>24) leadtime ranges. Results using all leadtimes will always be generated | lt_split: FALSE |
+| verif | skip_qc | Skip all quality control checks on observations and forecasts. Useful for debugging. Default is FALSE i.e. run the quality control checks. | skip_qc: FALSE |
 | verif | fcst_path    | Path to the forecast sqlite tables generated from the vfld. | fcst_path: "/path/to/FCTABLE" |
 | verif | obs_path     | Path to the observation sqlite tables generated from the vobs. | obs_path: "/path/to/OBSTBALE" |
 | verif | verif_path   | A root directory where the rds verification files are stored. For a given project, these rds files will be located in `verif:verif_path`/`verif:project_name`. | verif_path: "/path/to/rds" |
-| verif | model_as_obs | An extra set of options which indicates that you want to use a forecast model analysis as observations. This will read lead time=0 forecasts from the sqlite. An extra set of options are nested from `model_as_obs`, see example and options below | model_as_obs: <br>  model_as_obs_name: X <br>  model_as_obs_path: X <br>  model_as_obs_tmpl: X |
+| verif | model_as_obs | An extra set of options which indicates that you want to use a forecast model analysis as observations. This will read lead time=0 forecasts from the sqlite. An extra set of options are nested from `model_as_obs`, see example and options below | model_as_obs: <br>  model_as_obs_name: X <br>  model_as_obs_path: X <br>  model_as_obs_by: X <br>  model_as_obs_tmpl: X |
 | verif$model_as_obs | model_as_obs_name | The name of the forecast model to read as observations | model_as_obs_name: model_A |
 | verif$model_as_obs | model_as_obs_path | The path to the forecast database to read as observations | model_as_obs_path: "/path/to/FCTABLE" |
+| verif$model_as_obs | model_as_obs_by | The frequency interval to read the forecast database. Defaults to "1h". Not all analysis files are required to exist. | model_as_obs_by: "3h" |
 | verif$model_as_obs | model_as_obs_tmpl | The file template to use for the forcast database to read as observations | model_as_obs_tmpl: "fctable" | 
 | pre   | fcst_model   | Carry out the vfld to sqlite conversion for these forecast models. Note that this can differ from `verif:fcst_model` (e.g. the sqlite tables may already exist for some models, and you may want to skip regenerating these). | fcst_model: <br> - model_A  <br> - model_B | 
 | pre   | lead_time    | Which lead times to use when converting the vfld. Can differ from `verif:lead_time`. | lead_time: seq(0,48,1) |
@@ -142,6 +144,22 @@ Create a configuration file for your project using the structure provided in the
 | scorecards | parallel    | Use parallel processing when performing the bootstrapping. | parallel: FALSE | 
 | scorecards | num_cores   | Number of cores to use if `parallel=TRUE`. | num_cores: 1 |
 | scorecards | plot_signif | As well as the scorecard, plot the actual score difference as a function of leadtime for each parameter and score (provided that `scorecards:create_scrd` is TRUE). Statistical significance of the score difference is also indicated. Uses `fn_plot_signif_diff.R`. | plot_signif: TRUE | 
+
+## Avoiding config file duplication!
+
+These config files can obviously get quite long given the large number of options available (both required and optional). Frequently you will just want to change one or two options in a configuration file, and as such duplication of all of the other options is a pain. A convenient way of handling this is to use an "experiment" config file, just containing the options you want to change, which references a "base" config file which contains all of the options. If an option is not defined in your "experiment" config file, it will be inherited from the value set in the "base" config file. You can do this by using the `inherits` option as below:
+
+```
+$ cat experiment_config.yml
+inherits: "base_config.yml"
+verif:
+  project_name: "new_project_name"
+  fcst_model:
+    - old_model
+    - new_model
+```
+
+Note that the config file pointed to by `inherits` should exist in directory `config_files`.
 # Pre-processing
 
 Typically the vfld and vobs files need to be converted to sqlite tables before starting the verification process. 

--- a/verification/fn_station_selection.R
+++ b/verification/fn_station_selection.R
@@ -151,8 +151,8 @@ fn_station_selection <- function(domain_choice = "All_Domains",
   # is used to generate lists based on SID ranges. 
   # latlon_reserved_names are used to generate lists defined by lat/lon
   # bounding boxes, while poly_reserved_names looks for .poly files
-  latlon_reserved_names <- c("DINI","IE_EN","IS","NL","NL_OP","DK","IRL","SCD",
-                             "FR","DE","Alps")
+  latlon_reserved_names <- c("DINI","IE_EN","IS","NL","NL_OP","DK","IRL","IoI",
+                             "SCD","FR","DE","Alps")
   synop_reserved_names  <- paste0(c("France","Germany","Ireland","Norway",
                                     "Sweden","Finland","Iceland","Greenland",
                                     "Denmark","Netherlands","Spain",
@@ -1279,6 +1279,11 @@ define_latlonbounds <- function(domain){
     wlon <- -11
     nlat <- 55.5
     elon <- -6
+  } else if (domain == "IoI") {
+    slat <- 51.25
+    wlon <- -10.25
+    nlat <- 55.5
+    elon <- -5.75
   } else if (domain == "SCD") { # Scandinavia bounding box
     slat <- 55
     wlon <- 4.5 

--- a/verification/fn_verif_helpers.R
+++ b/verification/fn_verif_helpers.R
@@ -16,6 +16,110 @@ suppressPackageStartupMessages({
 })
 
 #================================================#
+# MERGING AND LOAD YAML FILES
+#================================================#
+
+merge_yaml <- function(base, override) {
+  
+  for (nm in names(override)) {
+    
+    if (
+      nm %in% names(base) &&
+      is.list(base[[nm]]) &&
+      is.list(override[[nm]])
+    ) {
+      base[[nm]] <- merge_yaml(base[[nm]], override[[nm]])
+    } else {
+      base[[nm]] <- override[[nm]]
+    }
+  }
+  
+  return(base)
+}
+
+load_config <- function(path) {
+  
+  cfg <- yaml::read_yaml(path)
+  
+  if (!is.null(cfg$inherits)) {
+    
+    parent <- load_config(file.path(dirname(path),cfg$inherits))
+    
+    cfg$inherits <- NULL
+    
+    cfg <- merge_yaml(parent, cfg)
+  }
+  
+  return(cfg)
+  
+}
+
+#================================================#
+# PARSE INPUT params_list INTO A SET OF PARAMETERS
+# BASED ON params
+#================================================#
+
+parse_input_params <- function(params_list,params) {
+  # Get rid of whitespace and split into parameters
+  params_list <- stringr::str_split_1(gsub(" ","",params_list),",") %>% unique()
+  # Allow for single UA levels by splitting params_list into standard (i.e. 
+  # appearing explicitly in set_params file) and other parts
+  params_list_standard  <- params_list[params_list %in% names(params)]
+  params_list_UA_levels <- setdiff(params_list,params_list_standard)
+  # First get the standard params
+  params_orig <- params
+  params      <- params[params_list_standard]
+  # Remove empty entries
+  params      <- params[lapply(params,length) > 0]
+  # Save the first parameter found to use with create_station_filter
+  if (length(names(params)) > 0) {
+    param_csf <- names(params)[1]
+  } else {
+    param_csf <- NULL
+  }
+  
+  # Then handle single UA_levels e.g. T925
+  if (length(params_list_UA_levels) > 0) {
+    for (ual in params_list_UA_levels) {
+      # Strip trailing level from ual
+      uav <- gsub('[0-9]+$','',ual)
+      # Does the corresponding UA variable exist in the params file?
+      if (uav %in% names(params_orig)) {
+        param_ual <- params_orig[uav]
+        names(param_ual) <- ual
+        # Remove vc if it exists
+        if (!is.null(param_ual[[ual]][["vc"]])) {
+          param_ual[[ual]][["vc"]] <- NULL
+        }
+        params <- c(params,param_ual)
+        # If param_csf is not set, do so here (to the uav value!)
+        if (is.null(param_csf)) {
+          param_csf <- uav
+        }
+      } else {
+        cat("Did not find any match for",ual,"in the parameter file\n")
+      }
+    }
+  }
+  # Check that all entries are unique
+  if ((length(names(params))) != (length(unique(names(params))))) {
+    stop("There are repeated entries in params - why did this happen?")
+  }
+  
+  # Remove empty entries
+  params      <- params[lapply(params,length) > 0]
+  if (length(params) == 0) {
+    cat("Could not find any of the parameters:",
+        paste(params_list,collapse = ","),"\n")
+    stop("No parameters found!")
+  } else {
+    cat("Running for parameter(s):",paste(names(params),collapse = ","),"\n")
+  }
+  return(list("params"    = params,
+              "param_csf" = param_csf))
+}
+
+#================================================#
 # SILENT STOP WHEN RUNNING USING Rscript
 # WHEN IN RSTUDIO, DEFAULT BACK TO STOP TO AVOID
 # TERMINATING THE SESSION
@@ -89,11 +193,16 @@ check_config_input <- function(config,x,y,default="None",z=NULL) {
   
   if (is.null(val)) {
     cat("Could not find",x,":",y,"in the config\n")
-    if (default == "None") {
-      stop("No default value set for ",y,", aborting")
+    if (is.null(default)) {
+      cat("Setting",y,"= NULL\n")
+      val <- NULL
     } else {
-      cat("Setting",y,"=",default[[1]],"\n")
-      val <- default
+      if (default == "None") {
+        stop("No default value set for ",y,", aborting")
+      } else {
+        cat("Setting",y,"=",default[[1]],"\n")
+        val <- default
+      }
     }
   }
   
@@ -122,7 +231,8 @@ check_dirs_exist <- function(dir_vec) {
 
 get_named_list <- function(input_str,
                            fcst_model,
-                           str_descrip){
+                           str_descrip,
+                           skip_parse = FALSE){
   
   input_str <- as.list(input_str)
   if (length(input_str) == 1) {
@@ -137,7 +247,7 @@ get_named_list <- function(input_str,
   for (ii in seq(1,length(input_str),1)) {
     if (!is.null(input_str[[ii]])) {
       # Deal with case where lags is specified as "0h" etc, not in c() format
-      if ((any(input_str[[ii]] %in% paste0(seq(0,23),"h"))) || (str_descrip == "file_template")) {
+      if ((any(input_str[[ii]] %in% paste0(seq(0,23),"h"))) || (skip_parse)) {
         out[[ii]] <- input_str[[ii]]
       } else {
         out[[ii]] <- eval(parse(text = input_str[[ii]]))
@@ -993,6 +1103,26 @@ try_rpforecast <- function(start_date,
 
 scale_fcst <- function(fcst,prm_info) {
   
+  if (!is.null(prm_info$scale_fcst_specific)) {
+    if (is.null(prm_info$scale_fcst_rest)) {
+      stop("You need to use scale_fcst_rest with scale_fcst_specific!")
+    }
+    prm_info$scale_fcst <- prm_info$scale_fcst_specific
+    rest_models <- setdiff(names(fcst),
+                           names(prm_info$scale_fcst_specific))
+    for (aa in rest_models) {
+      prm_info$scale_fcst[[aa]] <- prm_info$scale_fcst_rest
+    }
+    models_to_scale <- names(fcst)
+  } else {
+    models_to_scale <- NULL
+  }
+  
+  if (!is.null(models_to_scale)) {
+    cat("Overwrite models_to_scale with",models_to_scale,"when forecast scaling\n")
+    prm_info$models_to_scale <- models_to_scale
+  }
+  
   if (!is.null(prm_info$scale_fcst)) {
     # Check if we need to scale models differently for this parameter
     if (is.null(prm_info$models_to_scale)) {
@@ -1232,7 +1362,21 @@ fcst_qc <- function(fcst,
                     param,
                     param_info,
                     vc,
-                    num_days){
+                    num_days,
+                    model_as_obs,
+                    skip_qc = FALSE){
+  
+  if (skip_qc) {
+    cat("Skipping the obs quality control checks as skip_qc is activated!\n")
+    return(fcst)
+  }
+  
+  # If using model analysis as observations, there is no need to run the
+  # forecast quality control checks
+  if (!isFALSE(model_as_obs)) {
+    cat("Skipping the obs quality control checks as you are using model analyses as observations!\n")
+    return(fcst)
+  }
   
   # Check that data exists for all models
   min_rows <- nrow(fcst[[1]])

--- a/verification/point_verif.R
+++ b/verification/point_verif.R
@@ -197,7 +197,7 @@ source(here::here(params_file))
 
 cat("%%%%%%%%% point_verif: Using config file",config_file,"and parameter file",params_file,"%%%%%%%%%\n")
 
-CONFIG          <- yaml::yaml.load_file(here::here(config_file))
+CONFIG          <- load_config(here::here(config_file))
 project_name    <- check_config_input(CONFIG,"verif","project_name")
 fcst_model      <- check_config_input(CONFIG,"verif","fcst_model")
 lead_time_str   <- check_config_input(CONFIG,"verif","lead_time")
@@ -211,7 +211,21 @@ model_as_obs    <- check_config_input(CONFIG,"verif","model_as_obs",default=FALS
 if (!isFALSE(model_as_obs)) {
   model_as_obs_name <- check_config_input(CONFIG,"verif","model_as_obs",z="model_as_obs_name")
   model_as_obs_path <- check_config_input(CONFIG,"verif","model_as_obs",z="model_as_obs_path")
+  model_as_obs_by   <- check_config_input(CONFIG,"verif","model_as_obs",z="model_as_obs_by",default = "1h")
   model_as_obs_tmpl <- check_config_input(CONFIG,"verif","model_as_obs",z="model_as_obs_tmpl",default = "fctable")
+}
+use_climatology <- check_config_input(CONFIG,"verif","use_climatology",default=FALSE)
+if (!isFALSE(use_climatology)) {
+  climatology_name <- check_config_input(CONFIG,"verif","use_climatology",z="climatology_name")
+  climatology_path <- check_config_input(CONFIG,"verif","use_climatology",z="climatology_path")
+  climatology_year <- check_config_input(CONFIG,"verif","use_climatology",z="climatology_year")
+  climatology_by   <- check_config_input(CONFIG,"verif","use_climatology",z="climatology_by",default = "1h")
+  climatology_tmpl <- check_config_input(CONFIG,"verif","use_climatology",z="climatology_tmpl",default = "fctable")
+  clim_in_plots    <- check_config_input(CONFIG,"verif","use_climatology",z="clim_in_plots",default = FALSE)
+  use_climatology  <- TRUE
+} else {
+  climatology_name <- NULL
+  clim_in_plots    <- FALSE
 }
 verif_path      <- check_config_input(CONFIG,"verif","verif_path")
 domains         <- check_config_input(CONFIG,"verif","domains",default="All")
@@ -225,6 +239,7 @@ ua_fcst_cycle   <- check_config_input(CONFIG,"verif","ua_fcst_cycle",default=F)
 ua_restrict_vh  <- check_config_input(CONFIG,"verif","ua_restrict_vh",default=T)
 lt_split        <- check_config_input(CONFIG,"verif","lt_split",default=F)
 force_valid_thr <- check_config_input(CONFIG,"verif","force_valid_thr",default=F)
+skip_qc         <- check_config_input(CONFIG,"verif","skip_qc",default=F)
 plot_output     <- check_config_input(CONFIG,"post","plot_output",default="default")
 create_png      <- check_config_input(CONFIG,"post","create_png",default=T)
 use_parallel    <- check_config_input(CONFIG,"post","use_parallel",default=F)
@@ -240,17 +255,20 @@ create_scrd     <- check_config_input(CONFIG,"scorecards","create_scrd",default=
 members_list    <- get_named_list(members,fcst_model,"members")
 lags_list       <- get_named_list(lags,fcst_model,"lags")
 shifts_list     <- get_named_list(shifts,fcst_model,"shifts")
-file_template   <- get_named_list(file_template,fcst_model,"file_template")
+file_template   <- get_named_list(file_template,fcst_model,"file_template",skip_parse=T)
 
 # Abort if directories do not exist
 check_dirs_exist(c(fcst_path,obs_path,verif_path))
 
-if ((!dir.exists(plot_output)) & (plot_output != "default")) {
+if ((!dir.exists(plot_output)) && (!(plot_output %in% c("default","png")))) {
   stop(plot_output," does not exist")
 }
 
-if (plot_output == "default") {
-  plot_output   <- file.path(verif_path,"archive")
+if (plot_output %in% c("default","png")) {
+  dstr <- switch(plot_output,
+                 "default" = "archive",
+                 "png"     = "png")
+  plot_output   <- file.path(verif_path,dstr)
   if (!dir.exists(plot_output)) {
     dir.create(plot_output,showWarnings = TRUE,recursive = FALSE)
   }
@@ -330,61 +348,9 @@ missing_data <- list("verif"   = NA_character_,
 if (params_list == "ALL") {
   cat("Verify all parameters in",params_file," (this is NOT recommended!)\n")
 } else {
-  # Get rid of whitespace and split into parameters
-  params_list <- stringr::str_split_1(gsub(" ","",params_list),",") %>% unique()
-  # Allow for single UA levels by splitting params_list into standard (i.e. 
-  # appearing explicitly in set_params file) and other parts
-  params_list_standard  <- params_list[params_list %in% names(params)]
-  params_list_UA_levels <- setdiff(params_list,params_list_standard)
-  # First get the standard params
-  params_orig <- params
-  params      <- params[params_list_standard]
-  # Remove empty entries
-  params      <- params[lapply(params,length) > 0]
-  # Save the first parameter found to use with create_station_filter
-  if (length(names(params)) > 0) {
-    param_csf <- names(params)[1]
-  } else {
-    param_csf <- NULL
-  }
-
-  # Then handle single UA_levels e.g. T925
-  if (length(params_list_UA_levels) > 0) {
-    for (ual in params_list_UA_levels) {
-      # Strip trailing level from ual
-      uav <- gsub('[0-9]+$','',ual)
-      # Does the corresponding UA variable exist in the params file?
-      if (uav %in% names(params_orig)) {
-        param_ual <- params_orig[uav]
-        names(param_ual) <- ual
-        # Remove vc if it exists
-        if (!is.null(param_ual[[ual]][["vc"]])) {
-          param_ual[[ual]][["vc"]] <- NULL
-        }
-        params <- c(params,param_ual)
-        # If param_csf is not set, do so here (to the uav value!)
-        if (is.null(param_csf)) {
-          param_csf <- uav
-        }
-      } else {
-        cat("Did not find any match for",ual,"in the parameter file\n")
-      }
-    }
-  }
-  # Check that all entries are unique
-  if ((length(names(params))) != (length(unique(names(params))))) {
-    stop("There are repeated entries in params - why did this happen?")
-  }
-  
-  # Remove empty entries
-  params      <- params[lapply(params,length) > 0]
-  if (length(params) == 0) {
-    cat("Could not find any of the parameters:",
-        paste(params_list,collapse = ","),"\n")
-    stop("No parameters found!")
-  } else {
-    cat("Running for parameter(s):",paste(names(params),collapse = ","),"\n")
-  }
+  pt        <- parse_input_params(params_list,params)
+  params    <- pt$params
+  param_csf <- pt$param_csf
 }
 
 # Make the grps for different verification types
@@ -400,6 +366,17 @@ grps_surface_default <- grps_surface_default[grepl("station_group",
                                              grps_surface_default,fixed = TRUE)]
 grps_UA_default      <- grps_UA_default[grepl("station_group",
                                              grps_UA_default,fixed = TRUE)]
+
+# Change valid_dttm grouping if you are looking at a longer period of time
+valid_dttm_col <- "valid_dttm"
+if (num_days > 100) {
+  cat("Aggregating data to daily scores for timeseries plots as you are looking at many days!\n")
+  valid_dttm_col <- "valid_ymd"
+  grps_surface_default <- lapply(grps_surface_default, function(x) {
+    x[x == "valid_dttm"] <- "valid_ymd"
+    x
+  })
+}
 
 # Convert num_ref_members to Inf if required
 if (!is.na(num_ref_members)) {
@@ -681,6 +658,96 @@ run_verif <- function(prm_info, prm_name) {
   }
   
   #================================================#
+  # ADD IN THE CLIMATOLOGY AS A MODEL
+  #================================================#
+  use_climatology_local <- use_climatology
+  climatology_name_local <- climatology_name
+  
+  if (use_climatology) {
+    
+    cat("Now add in climatology from model",climatology_name,"\n")
+    
+    if (fcst_type != "det") {
+      stop("Climatology option only working in determinstic mode so far!")
+    }
+    
+    # Valid days to grab
+    clim_days <- fcst[[1]]$valid_dttm %>% 
+      unique() %>%
+      harpCore::as_ymdh() %>%
+      sort() %>% 
+      substr(.,5,10)
+    clim_sdat <- paste0(climatology_year,min(clim_days))
+    clim_edat <- paste0(climatology_year,max(clim_days))
+    
+    # Then read in climatology data
+    clm_prm_name <- prm_name
+    if (grepl("AccPcp",prm_name,fixed = T)) {
+      clm_prm_name <- paste0("analysis_",clm_prm_name)
+    }
+    mm        <- list(NULL)
+    names(mm) <- climatology_name
+    lm        <- list("0h")
+    names(lm) <- climatology_name
+    clim_data <- try_rpforecast(clim_sdat,
+                                clim_edat,
+                                climatology_by,
+                                climatology_name,
+                                fcst_type,
+                                clm_prm_name,
+                                0,
+                                mm,
+                                lm,
+                                climatology_path,
+                                climatology_tmpl,
+                                stations_filter,
+                                vertical_coordinate)
+    if (is.null(clim_data)) {
+      
+      message("Failure during the climatology FCTABLE reading process for ",prm_name,
+              ", not using climatology for this parameter!")
+      use_climatology_local <- FALSE
+      climatology_name_local <- NULL
+      
+    } else {
+    
+      # Then filter to just month, day, hour, SID
+      cols_to_sel <- c("valid_dttm","SID","fcst")
+      cols_to_sel <- switch(
+        vertical_coordinate,
+        "pressure" = c(cols_to_sel,"p"),
+        "height"   = c(cols_to_sel,"z"),
+        cols_to_sel
+      )
+      clim_data <- clim_data %>% 
+        dplyr::select(all_of(cols_to_sel)) %>% 
+        dplyr::rename(clm = fcst) %>%
+        harpCore::expand_date(.,"valid_dttm") %>%
+        dplyr::select(-valid_dttm,-valid_year)
+      
+      # Make a fake forecast model based on first model and use it for climatology
+      qwe <- fcst[[1]] %>% 
+        harpCore::expand_date(.,"valid_dttm") %>%
+        dplyr::select(-valid_year)
+      # If multiple years are present the same day may be matched multiple times, 
+      # hence many-to-one. Then replace forecast by climatology values.
+      qwe2 <- dplyr::inner_join(qwe,
+                                clim_data[[1]],
+                                relationship = "many-to-one",
+                                by = setdiff(colnames(clim_data[[1]]),"clm")) %>%
+        dplyr::mutate(fcst_model = climatology_name,fcst = clm) %>%
+        dplyr::select(-clm,-valid_month,-valid_day,-valid_hour,-valid_minute)
+      clim_data[[1]] <- qwe2
+      # Then add this in to forecast model object
+      fcst <- c(fcst,clim_data)
+      
+      cat("Added climatology successfully!\n")
+      
+    }
+    
+  }
+  
+  #================================================#
   # COMMON CASE, SCALE, FILTER TO MAX FORECAST
   #================================================#
 
@@ -756,12 +823,18 @@ run_verif <- function(prm_info, prm_name) {
     names(mm) <- model_as_obs_name
     lm        <- list("0h")
     names(lm) <- model_as_obs_name
+    if (grepl("AccPcp",prm_name,fixed = T)) {
+      obs_prm_name <- paste0("analysis_",prm_name)
+    } else {
+      obs_prm_name <- prm_name
+    }
+    cat("Using parameter name",obs_prm_name,"when reading lead_time=0 forecasts\n")
     obs <- try_rpforecast(all_valid[1],
                           tail(all_valid,1),
-                          "1h",
+                          model_as_obs_by,
                           model_as_obs_name,
                           fcst_type,
-                          prm_name,
+                          obs_prm_name,
                           0,
                           mm,
                           lm,
@@ -774,6 +847,14 @@ run_verif <- function(prm_info, prm_name) {
       message("Failure during the FCTABLE reading process for ",prm_name,
               ", moving on to the next parameter")
       return(missing_data)
+    }
+    
+    if (unique(obs[[1]]$parameter) != prm_name) {
+      if ((unique(obs[[1]]$parameter) == obs_prm_name) && (grepl("AccPcp",obs_prm_name,fixed = T))) {
+        obs[[1]]$parameter <- "Pcp"
+      } else {
+        stop("Something weird happened with the parameter name when reading forecasts as obs")
+      }
     }
     
     # Now scale and drop columns
@@ -825,7 +906,9 @@ run_verif <- function(prm_info, prm_name) {
                   {{prm_name}},
                   prm_info,
                   vertical_coordinate,
-                  num_days)
+                  num_days,
+                  model_as_obs,
+                  skip_qc = skip_qc)
   if (is.null(fcst)) {
     message("Failure after the QC check for parameter ",prm_name,
             ", moving on to next parameter")
@@ -849,6 +932,10 @@ run_verif <- function(prm_info, prm_name) {
   fcst <- harpCore::expand_date(fcst,valid_dttm)
   fcst <- harpPoint::mutate_list(fcst,
                                  valid_hour = sprintf("%02d",valid_hour))
+  if (valid_dttm_col == "valid_ymd" ){
+    fcst <- harpPoint::mutate_list(fcst,
+                                   valid_ymd = as.Date(valid_dttm))
+  }
   
   # If UA variable, restrict to main valid hours i.e. 00, 06, 12, 18 Z
   if (!is.na(vertical_coordinate)) {
@@ -1004,7 +1091,7 @@ run_verif <- function(prm_info, prm_name) {
     #================================================#
     
     st_aux <- Sys.time()
-    if (is.na(vertical_coordinate) & (create_png) & (!skip_aux_plots)) {
+    if ((create_png) & (!skip_aux_plots)) {
       fn_plot_aux_scores(fcst,
                               plot_output,
                               png_projname  = png_projname,
@@ -1014,7 +1101,10 @@ run_verif <- function(prm_info, prm_name) {
                               lt_split      = lt_split,
                               fsd           = fsd,
                               fed           = fed,
-                              use_parallel  = use_parallel)
+                              use_parallel  = use_parallel,
+                              vc            = vertical_coordinate,
+                              clim_name     = climatology_name_local,
+                              clim_in_plots = clim_in_plots)
     }
     et_aux <- Sys.time()
     dt_aux <- round(as.numeric(et_aux - st_aux,units = "secs"))
@@ -1044,6 +1134,43 @@ run_verif <- function(prm_info, prm_name) {
     verif_toplot <- verif_all$verif_toplot
     verif_sid    <- verif_all$verif_sid
     
+    # If climatology is available, compute some skill scores relative to this
+    if (use_climatology_local) {
+      
+      if (fcst_type == "det") {
+        verif_toplot[[1]] <- verif_toplot[[1]] %>% 
+          dplyr::mutate(mse = (rmse)**2)
+        verif_ss_clim <- verif_toplot[[1]] %>%
+          dplyr::filter(fcst_model == climatology_name) %>%
+          dplyr::mutate(mse_clm = mse) %>%
+          dplyr::select(-fcst_model,-bias,-rmse,-mae,-stde,-mse)
+        if ("mean_fcst" %in% colnames(verif_ss_clim)) {
+          verif_ss_clim <- verif_ss_clim %>% dplyr::select(-mean_fcst,-mean_obs)
+        }
+        cnames = setdiff(intersect(colnames(verif_ss_clim),
+                                   colnames(verif_toplot[[1]])),
+                         c("fcst_model","mse_clm"))
+        verif_toplot[[1]] <- dplyr::inner_join(
+          verif_toplot[[1]],
+          verif_ss_clim,
+          relationship = "many-to-one",
+          by = cnames
+        ) %>%
+          dplyr::mutate(msss = 1 - (mse/mse_clm))
+      }
+      
+      # Then remove climatology from plotting if desired
+      if (!clim_in_plots) {
+        verif_toplot <- verif_toplot %>%
+          harpPoint::filter_list(fcst_model != climatology_name)
+        if ((is.na(vertical_coordinate)) & (!is.null(verif_sid))) {
+          verif_sid    <- verif_sid %>%
+            harpPoint::filter_list(fcst_model != climatology_name)
+        }
+      }
+      
+    }
+    
     #================================================#
     # CALL PLOTTING SCRIPT FOR DIFFERENT GROUPS
     #================================================#
@@ -1067,6 +1194,7 @@ run_verif <- function(prm_info, prm_name) {
       
       fn_plot_point_verif(verif_toplot,
                                plot_output,
+                               valid_dttm_col = valid_dttm_col,
                                png_projname  = png_projname,
                                rolling_verif = rolling_verif,
                                cmap          = cmap,
@@ -1075,6 +1203,7 @@ run_verif <- function(prm_info, prm_name) {
                                fed           = fed,
                                n_stations    = n_stations,
                                use_parallel  = use_parallel,
+                               clim_name     = climatology_name_local,
                                plot_num_obs  = TRUE,
                                fcst          = fcst)
       if ((is.na(vertical_coordinate)) & (!is.null(verif_sid))) {
@@ -1090,21 +1219,13 @@ run_verif <- function(prm_info, prm_name) {
                                  n_stations    = n_stations,
                                  use_parallel  = use_parallel)
         # Save the verification object used for SIDs if desired
-        if (save_sidrds) {
+        if ((save_sidrds) && (!rolling_verif)) {
           sidname <- paste(project_name,prm_name,"SID",start_date,end_date,sep = "_")
           saveRDS(object = verif_sid,
                   file   = file.path(plot_output,
                                      paste0(sidname,".rds")))
         }
       }
-    }
-    
-    # Save the verification object used for plotting pngs if desired
-    if (save_vofp) {
-      vtpname <- paste(project_name,prm_name,start_date,end_date,sep = "_")
-      saveRDS(object = verif_toplot,
-              file   = file.path(plot_output,
-                                 paste0(vtpname,".rds")))
     }
     
     et_plot <- Sys.time()
@@ -1131,6 +1252,15 @@ run_verif <- function(prm_info, prm_name) {
         harpIO::save_point_verif(verif,
                                  verif_path = verif_path)
       }
+      
+      # Save the verification object used for plotting pngs if desired
+      if (save_vofp) {
+        vtpname <- paste(project_name,prm_name,start_date,end_date,sep = "_")
+        saveRDS(object = verif_toplot,
+                file   = file.path(plot_output,
+                                   paste0(vtpname,".rds")))
+      }
+      
     }
         
   } else { # if gen_sc_only=TRUE
@@ -1205,78 +1335,15 @@ for (jj in names(params)) {
 # Generate scorecards/diffs if desired
 if ((create_scrd) & (sc_data_exists)) {
   
-  model_names <- NULL
-  score_names <- NULL
-  for (ii in seq(1,length(verif))) {
-    if (length(verif[[ii]][["sc_data"]]) > 0) {
-      # First domain, first tibble (i.e. summary scores)
-      qwe         <- unique(verif[[ii]][["sc_data"]][[1]][[1]][["fcst_model"]])
-      qwe2        <- unique(verif[[ii]][["sc_data"]][[1]][[1]][["score"]])
-      model_names <- unique(c(model_names,qwe))
-      score_names <- unique(c(score_names,qwe2))
-    }
-  }
-  sc_models <- c(CONFIG$scorecards$ref_model,
-                 CONFIG$scorecards$fcst_model)
+  fn_gen_sc_plots(verif,
+                  CONFIG,
+                  plot_output,
+                  verif_path,
+                  fsd,
+                  fed,
+                  png_projname = png_projname,
+                  tile_lts = seq(0,66,3))
   
-  # Check fcst/ref model consistency
-  for (ii in seq(1,length(sc_models))) {
-    scm <- sc_models[ii]
-    if (!(scm %in% model_names)) {
-      # Look for renamed version
-      if (any(grepl(scm,model_names,fixed = TRUE))) {
-        scm_renamed <- model_names[grepl(scm,model_names,fixed = TRUE)]
-        if (length(scm_renamed) == 1) {
-          cat("Using model name",scm_renamed,"instead of",scm,"\n")
-          sc_models[ii] <- scm_renamed
-        } else {
-          stop("Fringe case in scorecard model check, what's going on?")
-        }
-      } else {
-        stop("Model ",scm," was not found in scorecard data, aborting!")
-      }
-    }
-  }
-  
-  # Check score consistency
-  if (all(CONFIG$scorecards$scores %in% score_names)) {
-    sc_scores <- CONFIG$scorecards$scores
-  } else {
-    cat("Switch scorecard scores to default\n")
-    if ("mean_bias" %in% score_names) {
-      sc_scores <- c("mean_bias","rmse","crps","spread")
-    } else {
-      sc_scores <- c("bias","rmse","stde")
-    }
-  }
-  
-  scard_fname_out <- fn_scorecard_signif(verif,
-                                              sc_scores,
-                                              CONFIG$scorecards$parameters,
-                                              sc_models[2],
-                                              sc_models[1],
-                                              plot_output,
-                                              plot_signif = CONFIG$scorecards$plot_signif,
-                                              verif_path = verif_path,
-                                              png_projname = png_projname,
-                                              fsd  = fsd,
-                                              fed  = fed)
-  # Plot the "tile" scorecards
-  if (!is.na(scard_fname_out)) {
-    if (file.exists(scard_fname_out)) {
-      sc_data <- readRDS(scard_fname_out)
-      fn_plot_tile_scorecard(sc_data,
-                             sc_scores,
-                             sc_models[2],
-                             sc_models[1],
-                             plot_output,
-                             significance = 0.95,
-                             png_projname = png_projname,
-                             leadtimes = seq(0,66,3),
-                             fsd  = fsd,
-                             fed  = fed)
-    }
-  }
 }
 
 cat("%%%%%%%%%%%% point_verif: Finished config file",config_file,"%%%%%%%%%%%%\n")

--- a/visualization/fn_plot_aux_scores.R
+++ b/visualization/fn_plot_aux_scores.R
@@ -24,12 +24,24 @@ fn_plot_aux_scores <- function(fcst_input,
                                     plot_fd = FALSE,
                                     plot_scat = TRUE,
                                     use_parallel = FALSE,
+                                    clim_name = NULL,
+                                    clim_in_plots = FALSE,
+                                    vc = NA_character_,
                                     fsd = NA_character_,
                                     fed = NA_character_){
   
   #=================================================#
   # INITIAL CHECKS 
   #=================================================#
+  
+  if (!is.na(vc)) {
+    if (is.null(clim_name)) {
+      cat("Skipping fn_plot_aux_scores for this UA parameter\n")
+      return()
+    } else {
+      cat("Running fn_plot_aux_scores for this UA parameter as climatology was found!\n")
+    }
+  }
   
   if (!is.list(fcst_input)) {
     stop("Aux scores plotting: A harp forecast object is required, aborting")
@@ -91,6 +103,12 @@ fn_plot_aux_scores <- function(fcst_input,
   if (!(station_group_var %in% fcst_names)) {
     fcst <- harpPoint::mutate_list(fcst,"{station_group_var}" := "All")
   }
+  # If valid_ymd exists, use this as the grouping variable
+  if ("valid_ymd" %in% fcst_names) {
+    valid_dttm_col <- "valid_ymd"
+  } else {
+    valid_dttm_col <- "valid_dttm"
+  }
   
   # Useful variables
   param    <- unique(fcst[["parameter"]])
@@ -138,8 +156,10 @@ fn_plot_aux_scores <- function(fcst_input,
   #=================================================#
   
   lt_to_use   <- seq(3,48,3) # What lead_times to use (hours)?
-  if (attr(fcst_input,"lt_unit") != "h") {
-    stop("Lead time generalisation required - raise an issue!")
+  if (!is.null(attr(fcst_input,"lt_unit"))){
+    if (attr(fcst_input,"lt_unit") != "h") {
+      stop("Lead time generalisation required - raise an issue!")
+    }
   }
   all_lts     <- sort(unique(fcst[["lead_time"]]))
   lt_to_use   <- intersect(all_lts,lt_to_use)
@@ -159,6 +179,12 @@ fn_plot_aux_scores <- function(fcst_input,
                             "lt_long"  = lt_to_use_long)
   } else {
     lt_to_use_list  <- list("lt_all" = lt_to_use)
+  }
+  # If climatology exists, use all lead times for forecast activity
+  if (!is.null(clim_name)) {
+    if (!(all(all_lts %in% lt_to_use))) {
+      lt_to_use_list  <- c(lt_to_use_list,list("lt_clm" = all_lts))
+    }
   }
   cycles_oi   <- c("All","00","12") # What cycles to plot for?
   if (rolling_verif) {
@@ -377,7 +403,46 @@ fn_plot_aux_scores <- function(fcst_input,
       # Split by fcst_type
       if (fcst_type == "det") {
         
+        if (!is.null(clim_name)) {
+          
+          # Compute NFA if you are using all leadtimes possible
+          if (all(all_lts %in% leadtimes)) {
+            # Compute normalised forecast activity
+            vroption_list$score   <- "nfa"
+            vroption_list$xgroup  <- "lead_time"
+            vroption_list$lt_used <- "NA"
+            vroption_list$xg_str  <- "lt"
+            p <- fn_nfa(cc_fcst,
+                        title_str,
+                        subtitle_str,
+                        fxoption_list,
+                        vroption_list,
+                        clim_name,
+                        vc = vc)
+            p_list <- c(p_list,p)
+            # Reset
+            vroption_list$score   <- "score"
+            vroption_list$xgroup  <- "xgroup"
+            vroption_list$lt_used <- lt_used
+            vroption_list$xg_str  <- "xg_str"
+            
+            # Skip the rest of the below, no need to run for this set of leadtimes
+            # However if we are on the first leadtime loop, then continue to below!
+            # (case when all_lts are in lt_to_use)
+            if (jj > 1) {
+              next
+            }
+          }
+          
+          # Remove climatology from plots if specified
+          if (!clim_in_plots) {
+            cc_fcst <- cc_fcst %>% dplyr::filter(fcst_model != clim_name)
+          }
+          
+        }
+        
         # All aux scores
+        if (is.na(vc)) {
         p <- fn_aux(cc_fcst,
                title_str,
                subtitle_str,
@@ -388,9 +453,11 @@ fn_plot_aux_scores <- function(fcst_input,
                plot_scat = plot_scat,
                use_parallel = use_parallel)
         p_list <- c(p_list,p)
+        }
           
       } else if (fcst_type == "ens") {
         
+        if (is.na(vc)){
         # Compute scores for the ensemble mean
         cc_fcst_mean <- cc_fcst %>% dplyr::filter(member == "mean")
         c_title_str  <- paste0("Ensemble mean : ",title_str)
@@ -437,9 +504,9 @@ fn_plot_aux_scores <- function(fcst_input,
                      use_parallel = use_parallel)
           p_list <- c(p_list,p)
           
-          group_vars           <- c("fcst_model","valid_dttm","member")
+          group_vars           <- c("fcst_model",valid_dttm_col,"member")
           vroption_list$score  <- "mbrtimeseries"
-          vroption_list$xgroup <- "valid_dttm"
+          vroption_list$xgroup <- valid_dttm_col
           vroption_list$xg_str <- "vd"
           p <- fn_dvar_ts(cc_fcst,
                      group_vars,
@@ -462,6 +529,7 @@ fn_plot_aux_scores <- function(fcst_input,
           }
           
         }
+        } # vc check
         
       } # Det/eps
         

--- a/visualization/fn_plot_helpers.R
+++ b/visualization/fn_plot_helpers.R
@@ -9,6 +9,94 @@
 numbers_only <- function(x) !grepl("\\D", x)
 
 #================================================#
+# GENERATE SCORECARD PLOTS
+#================================================#
+
+fn_gen_sc_plots <- function(verif,
+                            CONFIG,
+                            plot_output,
+                            verif_path,
+                            fsd,
+                            fed,
+                            png_projname = NA_character_,
+                            tile_lts = seq(0,66,3)) {
+  
+  model_names <- NULL
+  score_names <- NULL
+  for (ii in seq(1,length(verif))) {
+    if (length(verif[[ii]][["sc_data"]]) > 0) {
+      # First domain, first tibble (i.e. summary scores)
+      qwe         <- unique(verif[[ii]][["sc_data"]][[1]][[1]][["fcst_model"]])
+      qwe2        <- unique(verif[[ii]][["sc_data"]][[1]][[1]][["score"]])
+      model_names <- unique(c(model_names,qwe))
+      score_names <- unique(c(score_names,qwe2))
+    }
+  }
+  sc_models <- c(CONFIG$scorecards$ref_model,
+                 CONFIG$scorecards$fcst_model)
+  
+  # Check fcst/ref model consistency
+  for (ii in seq(1,length(sc_models))) {
+    scm <- sc_models[ii]
+    if (!(scm %in% model_names)) {
+      # Look for renamed version
+      if (any(grepl(scm,model_names,fixed = TRUE))) {
+        scm_renamed <- model_names[grepl(scm,model_names,fixed = TRUE)]
+        if (length(scm_renamed) == 1) {
+          cat("Using model name",scm_renamed,"instead of",scm,"\n")
+          sc_models[ii] <- scm_renamed
+        } else {
+          stop("Fringe case in scorecard model check, what's going on?")
+        }
+      } else {
+        stop("Model ",scm," was not found in scorecard data, aborting!")
+      }
+    }
+  }
+  
+  # Check score consistency
+  if (all(CONFIG$scorecards$scores %in% score_names)) {
+    sc_scores <- CONFIG$scorecards$scores
+  } else {
+    cat("Switch scorecard scores to default\n")
+    if ("mean_bias" %in% score_names) {
+      sc_scores <- c("mean_bias","rmse","crps","spread")
+    } else {
+      sc_scores <- c("bias","rmse","stde")
+    }
+  }
+  
+  scard_fname_out <- fn_scorecard_signif(verif,
+                                         sc_scores,
+                                         CONFIG$scorecards$parameters,
+                                         sc_models[2],
+                                         sc_models[1],
+                                         plot_output,
+                                         plot_signif = CONFIG$scorecards$plot_signif,
+                                         verif_path = verif_path,
+                                         png_projname = png_projname,
+                                         fsd  = fsd,
+                                         fed  = fed)
+  # Plot the "tile" scorecards
+  if (!is.na(scard_fname_out)) {
+    if (file.exists(scard_fname_out)) {
+      sc_data <- readRDS(scard_fname_out)
+      fn_plot_tile_scorecard(sc_data,
+                             sc_scores,
+                             sc_models[2],
+                             sc_models[1],
+                             plot_output,
+                             significance = 0.95,
+                             png_projname = png_projname,
+                             leadtimes = tile_lts,
+                             fsd  = fsd,
+                             fed  = fed)
+    }
+  }
+  
+}
+
+#================================================#
 # DROP VERIF ATTRIBUTES
 #================================================#
 
@@ -392,7 +480,7 @@ fn_plot_point <- function(verif,
   score_sep    <- fxoption_list$score_sep
   comp_val     <- fxoption_list$comp_val
   thr_brks     <- fxoption_list$thr_brks
-  
+  clim_name    <- fxoption_list$clim_name
   if (all(grepl("_scores",names(verif)))) {
     df <- verif[[paste0(c_ftyp,"_",c_typ,"_scores")]]
   } else {
@@ -429,6 +517,12 @@ fn_plot_point <- function(verif,
       mcolors <- mcolors[names(mcolors) != "OBS"]
       yl <- ""
     }
+  } else if (xgroup == "qobs") {
+    xl <- paste0("Sorted obs. (",par_unit,")")
+    yl <- paste0("Sorted forecasts (",par_unit,")")
+    stroke_size <- 0
+    point_size  <- 0
+    qobs_diag   <- TRUE
   }
   
   # A check on the type of xgroup (in case of character type for 
@@ -447,13 +541,34 @@ fn_plot_point <- function(verif,
   title_scores <- gsub("_"," ",stringr::str_to_title(title_scores)) 
   
   # Plot title
+  if (length(title_scores) == 1) {
+    if (title_scores == "Nfa") {
+      title_scores <- "Normalised Forecast Activity"
+    } else if (title_scores == "Msss") {
+      title_scores <- "Mean Squared Skill Score"
+      if (!is.null(clim_name)) {
+        subtitle_str <- paste0(subtitle_str," : Relative to ",clim_name)
+      }
+    } else if (title_scores == "Quant") {
+      title_scores <- "Quantile-Quantile"
+    } else if (title_scores == "Qdiff") {
+      title_scores <- "Quantile-Quantile difference"
+      yl <- paste0("Sorted forecasts - obs. (",par_unit,")")
+      qobs_diag <- FALSE
+    }
+  }
   ptitle <- paste0(paste0(title_scores,collapse = ", ")," : ",title_str)
   
   # Change point size if we are looking at valid_dttm
-  if (xgroup == "valid_dttm") {
+  if (xgroup %in% c("valid_dttm","valid_ymd")) {
     stroke_size <- 0
     point_size  <- 0
-    xl          <- "Valid date"
+    if (xgroup == "valid_dttm") {
+      xl       <- "Valid date"
+    } else if (xgroup == "valid_ymd") {
+      xl           <- "Valid day"
+      subtitle_str <- paste0(subtitle_str," : Data aggregated to daily temporal resolution")
+    }
   }
   
   # If looking at lead_time, use fixed y-limits if specified
@@ -530,7 +645,7 @@ fn_plot_point <- function(verif,
   } else if (any(grepl("mbr",all_scores))) {
     
     # If looking at valid_dttm, then use only one column
-    if (xgroup == "valid_dttm") {
+    if (xgroup %in% c("valid_dttm","valid_ymd")) {
       ncols = 1
     } else {
       ncols = min(num_models,2)
@@ -608,7 +723,7 @@ fn_plot_point <- function(verif,
       
     # Add zero line if relevant
     cp_ylim <- ggplot2::layer_scales(p_out)$y$range$range
-    if ((cp_ylim[1] < 0) && (cp_ylim[2] > 0)) {
+    if ((cp_ylim[1] < 0) && (cp_ylim[2] > 0) && (xgroup != "qobs")) {
       p_out <- p_out + ggplot2::geom_hline(yintercept = 0,
                                            linewidth  = line_size,
                                            color      = "black",
@@ -699,7 +814,7 @@ fn_plot_point <- function(verif,
     }
 
     cp_ylim <- layer_scales(p_out)$y$range$range
-    if ((cp_ylim[1] < 0) && (cp_ylim[2] > 0)) {
+    if ((cp_ylim[1] < 0) && (cp_ylim[2] > 0) && (xgroup != "qobs")) {
       p_out <- p_out + ggplot2::geom_hline(yintercept = 0,
                                           linewidth  = line_size,
                                           color      = "black",
@@ -716,6 +831,31 @@ fn_plot_point <- function(verif,
       p_out <- p_out + ggplot2::labs(
         subtitle = paste0(subtitle_str," (bins=(], min included, num obs > 0)")
       )
+    }
+    if (xgroup == "qobs") {
+      if (qobs_diag) {
+        cp_xlim <- layer_scales(p_out)$x$range$range
+        xy_min <- min(c(cp_xlim,cp_ylim))
+        xy_max <- max(c(cp_xlim,cp_ylim))
+        p_out <- p_out + ggplot2::geom_abline(intercept = 0,
+                                              slope     = 1,
+                                              color     = "black",
+                                              linewidth = 0.5) +
+          ggplot2::scale_x_continuous(limits = c(xy_min,xy_max)) +
+          ggplot2::scale_y_continuous(limits = c(xy_min,xy_max))
+      } else {
+        p_out <- p_out + ggplot2::geom_hline(yintercept = 0,
+                                             linewidth  = 0.5,
+                                             color      = "black")
+      }
+    }
+    if (length(all_scores) == 1) {
+      if (all_scores %in% c("nfa","msss")) {
+        p_out <- p_out + ggplot2::geom_hline(yintercept = 1,
+                                             linewidth  = line_size,
+                                             color      = "black",
+                                             linetype   = "dashed")
+      }
     }
     
     # Change to log axis for precip threshold scores, and add breaks
@@ -846,7 +986,7 @@ fn_plot_numcases <- function(verif,
   }
   
   # Reduce point size for timeseries plots
-  if (xgroup == "valid_dttm") {
+  if (xgroup %in% c("valid_dttm","valid_ymd")) {
     point_size <- 0
   }
   
@@ -1000,12 +1140,22 @@ fn_plot_map <- function(verif,
   score_sep  <- fxoption_list$score_sep
   param      <- fxoption_list$param
   map_cbar_d <- fxoption_list$map_cbar_d
-  if (score != "num_obs") {
-    df       <- verif[[paste0(c_ftyp,"_",c_typ,"_scores")]]
-  } else {
-    df       <- verif
+  geo_check  <- fxoption_list$geo_check
+  # Check for geolist
+  if (is.null(geo_check)) {
+    geo_check <- FALSE
   }
   
+  if (geo_check) {
+    df <- verif
+  } else {
+    if (score != "num_obs") {
+      df       <- verif[[paste0(c_ftyp,"_",c_typ,"_scores")]]
+    } else {
+      df       <- verif
+    }
+  }
+    
   # Split sscore into its individual parts
   all_scores   <- strsplit(score,score_sep)[[1]]
   num_scores   <- length(all_scores)
@@ -1019,34 +1169,50 @@ fn_plot_map <- function(verif,
   
   # In the map plotting it is assumed that the SID lat/lons are included in 
   # the verification object. Otherwise, nothing can be done
-  if ((all(c("lat","lon") %in% names(df))) & (num_scores == 1)) {
+  if (((all(c("lat","lon") %in% names(df))) & (num_scores == 1)) || (geo_check)) {
     
     # Colorbar options
-    c_min   <- min(df[[score]],na.rm = TRUE)
-    c_max   <- max(df[[score]],na.rm = TRUE)
-    min_lon <- min(df[["lon"]])
-    max_lon <- max(df[["lon"]])
-    min_lat <- min(df[["lat"]])
-    max_lat <- max(df[["lat"]])
-   
-    # If there is only one station, then skip!
-    if ( (min_lon == max_lon) & (min_lat == max_lat)) {
-	   warning("Skipping map plotting as only one SID found")
-	   return(NA_character_)
+    if (!geo_check) {
+      c_min   <- min(df[[score]],na.rm = TRUE)
+      c_max   <- max(df[[score]],na.rm = TRUE)
+      min_lon <- min(df[["lon"]])
+      max_lon <- max(df[["lon"]])
+      min_lat <- min(df[["lat"]])
+      max_lat <- max(df[["lat"]])
+     
+      # If there is only one station, then skip!
+      if ( (min_lon == max_lon) & (min_lat == max_lat)) {
+  	   warning("Skipping map plotting as only one SID found")
+  	   return(NA_character_)
+      }
+    } else {
+      c_min <- df[[score]] %>% unlist() %>% min()
+      c_max <- df[[score]] %>% unlist() %>% max()
     }
     
-    if (score == "num_obs") {
-      p_map <- df %>% ggplot2::ggplot(aes(lon,lat,
-                                          fill = .data[[score]]))
+    if (geo_check) {
+      geo_map <- get_map(df,col = {{score}}, polygon = T)
+      p_map   <- ggplot2::ggplot() +
+        harpVis::geom_georaster(aes(geofield = get(score)), df, na.rm = T) +
+        ggplot2::geom_polygon(
+          aes(x, y, group = group), geo_map, colour = "grey30", fill = "transparent"
+        ) 
     } else {
-      p_map <- df %>% ggplot2::ggplot(aes(lon,lat,
-                                          fill = .data[[score]],
-                                          size = abs(.data[[score]])))
+      if (score == "num_obs") {
+        p_map <- df %>% ggplot2::ggplot(aes(lon,lat,
+                                            fill = .data[[score]]))
+      } else {
+        p_map <- df %>% ggplot2::ggplot(aes(lon,lat,
+                                            fill = .data[[score]],
+                                            size = abs(.data[[score]])))
+      }
     }
     
     # Get the cmap and brks
-    cbar_opts <- fn_get_map_cbar(map_cbar_d,c_min,c_max,score,param,par_unit)
+    cbar_opts <- fn_get_map_cbar(map_cbar_d,c_min,c_max,score,param,par_unit,
+                                 geo_check = geo_check)
     
+    if (!geo_check){
     if (sf_available) {
       p_map <- p_map +
         ggplot2::geom_sf(data        = world,
@@ -1062,7 +1228,9 @@ fn_plot_map <- function(verif,
                               inherit.aes = FALSE)
     }
     p_map <- p_map +
-      ggplot2::geom_point(colour = 'grey40',pch = 21) + 
+      ggplot2::geom_point(colour = 'grey40',pch = 21)
+    }
+    p_map <- p_map +
       ggplot2::labs(title    = ptitle,
                     subtitle = subtitle_str,
                     fill     = "") +
@@ -1081,25 +1249,35 @@ fn_plot_map <- function(verif,
             legend.key.height         = unit(1.5,"cm"),
             strip.background          = ggplot2::element_rect(fill = "white"),
             strip.text                = ggplot2::element_text(size = 8))
-    if ((num_models > 1) && ("fcst_model" %in% names(df))) {
+    if (((num_models > 1) || (geo_check)) && ("fcst_model" %in% names(df))) {
       p_map <- p_map + 
         ggplot2::facet_wrap(
         vars(fcst_model),
         ncol = min(num_models,3))
     }
-    if (score != "num_obs") {
+    if ((score != "num_obs") && (!geo_check)) {
       p_map <- p_map +
         ggplot2::labs(size = "") +
         ggplot2::scale_size_continuous(range = c(0.1, 3)) + # Controls point size
         ggplot2::guides(size = "none") # Remove size label from legend
     }
       
+    if (!geo_check) {
     if (sf_available) {
       p_map <- p_map + ggplot2::coord_sf(xlim = c(min_lon-0.2,max_lon+0.2),
                                          ylim = c(min_lat-0.2,max_lat+0.2))
     } else {
       p_map <- p_map + ggplot2::coord_cartesian(xlim = c(min_lon-0.2,max_lon+0.2),
                                                 ylim = c(min_lat-0.2,max_lat+0.2))
+    }
+    } else {
+      p_map <- p_map + harpVis::theme_harp_map() +
+        ggplot2::theme(legend.key.height = unit(1.5,"cm"))
+      if (sf_available) {
+        p_map <- p_map + ggplot2::coord_sf(expand = FALSE)
+      } else {
+        p_map <- p_map + ggplot2::coord_cartesian(expand = FALSE)
+      }
     }
     
     if ((map_cbar_d) & (!is.null(cbar_opts$brks[1]))) {
@@ -1130,7 +1308,8 @@ fn_plot_map <- function(verif,
 # DEFINE THE COLOURBAR OPTIONS USED IN MAP PLOTTING
 #================================================#
 
-fn_get_map_cbar <- function(map_cbar_d,c_min,c_max,score,param,par_unit){
+fn_get_map_cbar <- function(map_cbar_d,c_min,c_max,score,param,par_unit,
+                            geo_check = FALSE){
   
   # Get breaks from this function
   gpc      <- get_param_classes(param,par_unit,score = score)
@@ -1156,7 +1335,11 @@ fn_get_map_cbar <- function(map_cbar_d,c_min,c_max,score,param,par_unit){
     scico_pal <- "vik"
     scico_dir <- 1
   } else {
-    scico_pal <-"lipari"
+    if (geo_check) {
+      scico_pal <- "lajolla"
+    } else {
+      scico_pal <-"lipari"
+    }
     scico_dir <- -1
   }
   cmap <- scico::scico(length(brks)-1,
@@ -1169,6 +1352,14 @@ fn_get_map_cbar <- function(map_cbar_d,c_min,c_max,score,param,par_unit){
                          begin     = 0.25,
                          end       = 0.75)
     cmap[length(brks)/2] <- "white"
+  }
+  if (geo_check) {
+    if (scico_pal == "vik") {
+      cmap[length(brks)/2] <- "white"
+    } else {
+      # Add white at bottom, drop the first colour
+      cmap <- c("white",cmap[2:length(cmap)])
+    }
   }
   
   # Then filter the cmap to just the colours which cover the range cmin-cmax
@@ -1584,11 +1775,37 @@ fn_aux <- function(fc,
       p_list[[length(p_list) + 1]] <- p[[1]]
       p_list[[length(p_list) + 1]] <- p[[2]]
     }
+    
+    # Quantile-quantile plots
+    vroption_list$xgroup <- "qobs"
+    vroption_list$score  <- paste0(cprefix,"quant")
+    vroption_list$xg_str <- "qobs"
+    p <- fn_quant(fc,
+                  title_str,
+                  subtitle_str,
+                  fxoption_list,
+                  vroption_list,
+                  use_parallel = use_parallel)
+    p_list[[length(p_list) + 1]] <- p
+    vroption_list$score  <- paste0(cprefix,"qdiff")
+    p <- fn_quant(fc,
+                  title_str,
+                  subtitle_str,
+                  fxoption_list,
+                  vroption_list,
+                  use_parallel = use_parallel)
+    p_list[[length(p_list) + 1]] <- p
+    
   }
   
   # Timeseries 
-  group_vars          <- c("fcst_model","valid_dttm")
-  vroption_list$xgroup <- "valid_dttm"
+  if ("valid_ymd" %in% names(fc)) {
+    group_vars           <- c("fcst_model","valid_ymd")
+    vroption_list$xgroup <- "valid_ymd"
+  } else {
+    group_vars           <- c("fcst_model","valid_dttm")
+    vroption_list$xgroup <- "valid_dttm"
+  }
   vroption_list$score  <- paste0(cprefix,"timeseries")
   vroption_list$xg_str <- "vd"
   p <- fn_dvar_ts(fc,
@@ -1712,6 +1929,194 @@ fn_dvar_ts <- function(fc,
                  "p_prof"    = FALSE)
   }
   return(p_info)
+}
+
+#================================================#
+# COMPUTE THE QUANTILE-QUANTILE PLOT
+#================================================#
+
+fn_quant <- function(fc,
+                     title_str,
+                     subtitle_str,
+                     fxoption_list,
+                     vroption_list,
+                     use_parallel = FALSE){
+  
+  # Read options
+  p_info     <- list()
+  score      <- vroption_list$score
+  station    <- vroption_list$station
+  score_orig <- score
+  if (grepl("mbr",score)) {
+    score <- gsub("mbr","",score)
+  }
+  
+  if (grepl("ctrl",score)) {
+    score               <- gsub("ctrl","",score)
+    vroption_list$score <- score
+  }
+  
+  # Get quants for each fcst_model
+  qq_inc  <- 0.01
+  qq_vals <- c(seq(qq_inc/10,2*qq_inc,qq_inc/10),
+               seq(2*qq_inc,1-2*qq_inc,qq_inc),
+               seq(1-2*qq_inc,1-(qq_inc/10),qq_inc/10)) %>% unique()
+  dv <- fc %>% 
+    dplyr::group_by(fcst_model) %>%
+    dplyr::reframe(quant = unname(quantile(fcst,qq_vals)))
+  # Get obs quants
+  dv_tmp <- fc %>% 
+    dplyr::filter(fcst_model == unique(fc$fcst_model)[1]) %>%
+    dplyr::group_by(fcst_model) %>%
+    dplyr::reframe(qobs = unname(quantile(OBS,qq_vals)))
+  dv$qobs <- rep(dv_tmp$qobs,length(unique(dv$fcst_model)))
+  # Also compute the diff in forecast and observed quant
+  dv <- dv %>%
+    dplyr::mutate(qdiff = quant - qobs)
+  
+  # Call plotting
+  if (!use_parallel) {
+    p_c <- fn_plot_point(dv,
+                         title_str,
+                         subtitle_str,
+                         fxoption_list,
+                         vroption_list)
+    
+    fn_save_png(p_c           = p_c,
+                fxoption_list = fxoption_list,
+                vroption_list = vroption_list,
+                fcst_type     = fxoption_list$c_ftyp,
+                score         = score_orig,
+                vlt           = vroption_list$lt_used)
+  } else {
+    p_info <- list("verif"     = dv,
+                   "title"     = title_str,
+                   "subtitle"  = subtitle_str,
+                   "vroptions" = vroption_list,
+                   "vlt"       = vroption_list$lt_used,
+                   "vth"       = "NA",
+                   "fcst_type" = fxoption_list$c_ftyp,
+                   "score"     = score_orig,
+                   "p_cases"   = FALSE,
+                   "p_map"     = FALSE,
+                   "p_prof"    = FALSE)
+  }
+  return(p_info)
+}
+
+#================================================#
+# COMPUTE THE NORMALISED FORECAST ACTVITY
+#================================================#
+
+fn_nfa <- function(fc,
+                   title_str,
+                   subtitle_str,
+                   fxoption_list,
+                   vroption_list,
+                   clim_name,
+                   vc = NA_character_){
+  
+  # Read options
+  p_info     <- list()
+  score      <- vroption_list$score
+  station    <- vroption_list$station
+  param      <- fxoption_list$param
+  score_orig <- score
+  if (grepl("mbr",score)) {
+    score <- gsub("mbr","",score)
+  }
+  if (grepl("ctrl",score)) {
+    score               <- gsub("ctrl","",score)
+    vroption_list$score <- score
+  }
+  
+  # Grab climatology from the dataset
+  clim_data  <- fc %>% 
+    dplyr::filter(fcst_model == clim_name) %>%
+    dplyr::mutate(clm = fcst) %>%
+    dplyr::select(-fcst,-fcst_model)
+  model_data <- fc %>% dplyr::filter(fcst_model != clim_name)
+  
+  # Merge climatology data into model data
+  model_data <- dplyr::inner_join(
+    model_data,
+    clim_data,
+    relationship = "many-to-one",
+    by = setdiff(colnames(clim_data),"clm")
+  )
+  
+  # Then compute the forecast activity. Need to be careful with vc
+  cols_to_grp <- c("fcst_model","lead_time")
+  ua_units    <- ""
+  if (!is.na(vc)) {
+    if (vc == "pressure") {
+      cols_to_grp <- c(cols_to_grp,"p")
+      ua_units    <- "hPa"
+    } else if (vc == "height") {
+      cols_to_grp <- c(cols_to_grp,"z")
+      ua_units    <- "m" # ??? assumed!
+    }
+  }
+  fc_act <- model_data %>% 
+    dplyr::group_by_at(cols_to_grp) %>%
+    dplyr::summarise(fcact = sd(fcst - clm),
+                     num_cases = n())
+  # And the observation activity (repeat over fcst_model for future merging)
+  ob_act <- model_data %>% 
+    dplyr::group_by_at(cols_to_grp) %>%
+    dplyr::summarise(obact = sd(OBS - clm),
+                     num_cases = n())
+  # Then the NFA
+  fc_act <- dplyr::inner_join(fc_act,
+                              ob_act,
+                              relationship="one-to-one",
+                              by = setdiff(colnames(ob_act),c("fcact","obact"))) %>%
+    dplyr::mutate(nfa = fcact/obact)
+
+  subtitle_str <- paste0(subtitle_str," : Relative to ",clim_name)
+  if ("p" %in% colnames(fc_act)) {
+    fc_act$iter <- fc_act$p
+  } else if ("z" %in% colnames(fc_act)) {
+    fc_act$iter <- fc_act$z
+  } else {
+    fc_act$iter <- -99 # dummy
+  }
+  iter_lvls <- unique(fc_act$iter)
+  
+  # Call plotting
+  for (iter_lvl in iter_lvls) {
+    
+    c_title_str <- title_str
+    if (iter_lvl >= 0) {
+      c_title_str  <- gsub(paste0(stringr::str_to_title(param)," : "),
+                           paste0(stringr::str_to_title(param),iter_lvl,ua_units," : "),
+                           c_title_str)
+      iter_lvl_png <- iter_lvl
+    } else {
+      iter_lvl_png <- "NA"
+    }
+  
+    p_c <- fn_plot_point(fc_act %>% dplyr::filter(iter == iter_lvl),
+                         c_title_str,
+                         subtitle_str,
+                         fxoption_list,
+                         vroption_list)
+    p_nc <- fn_plot_numcases(fc_act %>% dplyr::filter(iter == iter_lvl),
+                             fxoption_list,
+                             vroption_list)
+    p_c  <- fn_nc_combine(p_c,p_nc)
+    
+    fn_save_png(p_c           = p_c,
+                fxoption_list = fxoption_list,
+                vroption_list = vroption_list,
+                fcst_type     = fxoption_list$c_ftyp,
+                score         = score_orig,
+                vlt           = iter_lvl_png)
+    
+  }
+    
+  return(p_info)
+  
 }
 
 #================================================#
@@ -2036,7 +2441,7 @@ get_param_classes <- function(param,par_unit,score = "freq") {
                 "log_ind"  = FALSE))
   }
   
-  if (param %in% c("Pmsl")) {
+  if (param %in% c("Pmsl","msl")) {
     
     # Assuming hPa as default
     if (score %in% c("bias","mean_bias")) {
@@ -2058,7 +2463,7 @@ get_param_classes <- function(param,par_unit,score = "freq") {
       scale_round <- 0
     }
     
-  } else if (param %in% c("Ps")) {
+  } else if (param %in% c("Ps","sp")) {
     
     # Assuming hPa as default
     if (score %in% c("bias","mean_bias")) {
@@ -2080,10 +2485,30 @@ get_param_classes <- function(param,par_unit,score = "freq") {
       scale_round <- 0
     }
     
-  } else if ((param %in% c("T2m","Td2m","Tmax","Tmin")) || 
+  } else if ((gsub('[0-9]+$','',param) == "Z") ||
+             (gsub('[0-9]+$','',param) == "z")) {
+    
+    # Assuming m as default
+    if (score %in% c("bias","mean_bias")) {
+      brks <- seq(-30,-2.5,2.5)
+      brks <- c(brks,-1,1,-rev(brks))
+    } else if (score == "freq") {
+      brks <- seq(0,25000,100)
+    } else {
+      brks <- seq(0,40,2.5)
+    }
+    
+    if (par_unit %in% c("m")) {
+      scale_fac   <- 1
+      scale_mult  <- T
+      scale_round <- 0
+    }
+    
+  } else if ((param %in% c("T2m","Td2m","Tmax","Tmin","2t","t2m","skt")) || 
              (grepl("T2m",param,fixed=TRUE)) || 
              (gsub('[0-9]+$','',param) == "T") ||
-             (gsub('[0-9]+$','',param) == "Td")) {
+             (gsub('[0-9]+$','',param) == "Td") || 
+             (gsub('[0-9]+$','',param) == "t")) {
     
     # Assuming degC as default
     if (score %in% c("bias","mean_bias")) {
@@ -2134,9 +2559,10 @@ get_param_classes <- function(param,par_unit,score = "freq") {
       scale_round <- 4
     }
     
-  } else if ((param %in% c("S10m","Gmax","Smax","G10m")) ||
+  } else if ((param %in% c("S10m","Gmax","Smax","G10m","10u","10v","ws10m")) ||
              (grepl("S10m",param,fixed=TRUE)) ||
-             (gsub('[0-9]+$','',param) == "S")) {
+             (gsub('[0-9]+$','',param) == "S") || 
+             (gsub('[0-9]+$','',param) == "ws")) {
     
     # Assuming m/s as default
     if (score %in% c("bias","mean_bias")) {
@@ -2276,7 +2702,7 @@ get_param_classes <- function(param,par_unit,score = "freq") {
       scale_round <- 2
     }
     
-  } else if (grepl("Pcp",param,fixed=T)) {
+  } else if ((grepl("Pcp",param,fixed=T)) || (param %in% c("tp"))) {
     
     # Assuming mm/acc period (kg/m^2)
     if (score %in% c("bias","mean_bias")) {
@@ -2382,7 +2808,7 @@ fn_scatterplot <- function(fc,
       ggplot2::facet_wrap(vars((fcst_model)),
                           ncol = min(fxoption_list$num_models,3))
     max_count <- max(ggplot2::ggplot_build(p_scat)$data[[1]]$count)
-    br1       <- unique(round(logseq(1,max_count,5),0))
+    br1       <- unique(round(pracma::logseq(1,max_count,5),0))
     
     oto_col <- "black"
     if (fxoption_list$cmap_hex == "paired") {
@@ -2575,7 +3001,7 @@ fn_gen_model_colors <- function(in_names,
   # known models is pointless, and we return from here.
   if (is.null(model_colors)) {
     warning(cmap," does not have enough colours/is not in RColorBrewer or pals. As such known models will be ignored.")
-    cat("Using R's defualt line colors")
+    cat("Using R's default line colors\n")
     model_colors <- scales::hue_pal()(length(in_names))
     if (withobs) {
       model_colors <- c(model_colors,'#4F4F4F')

--- a/visualization/fn_plot_point_verif.R
+++ b/visualization/fn_plot_point_verif.R
@@ -8,6 +8,7 @@
 
 fn_plot_point_verif <- function(harp_verif_input,
                                      png_archive,
+                                     valid_dttm_col = "valid_dttm",
                                      plot_num_cases = TRUE,
                                      cmap = "Set2",
                                      map_cbar_d = FALSE,
@@ -19,8 +20,11 @@ fn_plot_point_verif <- function(harp_verif_input,
                                      fed = NA_character_,
                                      fylims = NULL,
                                      plevel_filter = TRUE,
+                                     pr_validh = c("00","12"),
                                      n_stations = NULL,
                                      use_parallel = FALSE,
+                                     cyc_summary = c("00","12","All"),
+                                     clim_name = NULL,
                                      plot_num_obs = FALSE,
                                      fcst = NULL){
  
@@ -94,7 +98,8 @@ fn_plot_point_verif <- function(harp_verif_input,
     # Scores as a fn of lead_time
     scores_lt  <- c(paste0("bias",score_sep,"rmse"),
                     paste0("bias",score_sep,"stde"),
-                    paste0("bias",score_sep,"mae"))
+                    paste0("bias",score_sep,"mae"),
+                    "rmse")
 
     # Scores as a fn of valid_dttm
     scores_vd  <- c(paste0("bias",score_sep,"stde"))
@@ -127,7 +132,7 @@ fn_plot_point_verif <- function(harp_verif_input,
     # summary
     # threshold scores as fn of lead_time
     # threshold scores as fn of threshold)
-    cycles_summary      <- c("00","12","All")
+    cycles_summary      <- cyc_summary
     cycles_threshold_lt <- c("All")
     cycles_threshold_th <- c("00","12","All")
     
@@ -135,10 +140,12 @@ fn_plot_point_verif <- function(harp_verif_input,
     
     # START OF UA SCORES
     # Scores as a fn of lead_time
-    p_scores_lt <- c(paste0("bias",score_sep,"rmse"))
+    p_scores_lt <- c(paste0("bias",score_sep,"rmse"),
+                     "rmse")
     
     # Profile scores
-    p_scores_pr <- c(paste0("bias",score_sep,"stde"))
+    p_scores_pr <- c(paste0("bias",score_sep,"stde"),
+                     "rmse")
     
     # END OF UA SCORES
     
@@ -156,13 +163,18 @@ fn_plot_point_verif <- function(harp_verif_input,
     # data does not exist in the verif object, it will be skipped
     
     xgroups    <- c("lead_time",
-                    "valid_dttm",
+                    valid_dttm_col,
                     "threshold_val",
                     "SID",
                     "p_leadtime",
                     "p_prof")
     if (rolling_verif) {
-      xgroups  <- c("lead_time","valid_dttm","SID")
+      xgroups  <- c("lead_time",valid_dttm_col,"SID")
+    }
+    
+    if (!is.null(clim_name)) {
+      scores_lt   <- c(scores_lt,"msss")
+      p_scores_lt <- c(p_scores_lt,"msss")
     }
 
     # EPS EXPERIMENT
@@ -242,7 +254,7 @@ fn_plot_point_verif <- function(harp_verif_input,
     # summary
     # threshold scores as fn of lead_time
     # threshold scores as fn of threshold
-    cycles_summary      <- c("00","12","All")
+    cycles_summary      <- cyc_summary
     cycles_threshold_lt <- c("All")
     cycles_threshold_th <- c("00","12","All")
     
@@ -269,14 +281,14 @@ fn_plot_point_verif <- function(harp_verif_input,
     
     # What groups are considered? (see description in "det" section above) 
     xgroups    <- c("lead_time",
-                    "valid_dttm",
+                    valid_dttm_col,
                     "threshold_val",
                     "SID",
                     "other",
                     "p_leadtime",
                     "p_prof")
     if (rolling_verif) {
-      xgroups  <- c("lead_time","valid_dttm","SID")
+      xgroups  <- c("lead_time",valid_dttm_col,"SID")
     }
 
   }
@@ -419,7 +431,8 @@ fn_plot_point_verif <- function(harp_verif_input,
                         "png_projname" = png_projname,
                         "score_sep"    = score_sep, 
                         "comp_val"     = attributes(verif)$comp_val,
-                        "thr_brks"     = attributes(verif)$thr_brks)
+                        "thr_brks"     = attributes(verif)$thr_brks,
+                        "clim_name"    = clim_name)
   
   #=====================================================#
   # NOW DO THE PLOTTING
@@ -448,7 +461,7 @@ fn_plot_point_verif <- function(harp_verif_input,
     if (xgroup == "lead_time") {
       xg_str <- "lt"
       scores <- scores_lt
-    } else if (xgroup == "valid_dttm") {
+    } else if (xgroup %in% c("valid_dttm","valid_ymd")) {
       xg_str <- "vd"
       scores <- scores_vd
     } else if (xgroup == "valid_hour") {
@@ -515,7 +528,7 @@ fn_plot_point_verif <- function(harp_verif_input,
       # when multiple xgroups are available. Not relevant for UA variables
       # as fcst_cycle is not a grouping variable.
       # This ensures that values relevant to this xgroup are used
-      if ((xgroup %in% c("lead_time","valid_hour","valid_dttm","threshold_val")) &
+      if ((xgroup %in% c("lead_time","valid_hour","valid_dttm","valid_ymd","threshold_val")) &
           (xgroup %in% cnames)) {
         c_ver          <- c_ver %>% dplyr::filter(get(xgroup) != "All")
       }
@@ -569,6 +582,14 @@ fn_plot_point_verif <- function(harp_verif_input,
       }
       station_group_var <- tmp_out$station_group_var
       rm(tmp_out)
+      
+      # If plotting skill scores with climatology, remove the climatology!
+      if (!is.null(clim_name)) {
+        if (score %in% c("msss")) {
+          verif <- verif %>% 
+            harpPoint::filter_list(fcst_model != clim_name)
+        }
+      }
       
       for (cycle in cycles) {
         
@@ -634,13 +655,13 @@ fn_plot_point_verif <- function(harp_verif_input,
               next
             }
           }
+          # Handle valid_dttm and only plot 3 hourly data
           if (("valid_dttm" %in% names(verif_II[[1]])) &
               (xgroup == "valid_dttm")) {
             verif_II <- verif_II %>%
               harpPoint::mutate_list(valid_dttm = harpCore::as_dttm(gsub("-| |:|UTC",
                                                                          "",
                                                                          valid_dttm)))
-            # Only plot 3 hourly data
             avddtm   <- harpCore::unique_valid_dttm(verif_II[[1]])
             exddtm   <- harpCore::as_dttm(harpCore::seq_dttm(avddtm[1],
                                                              tail(avddtm,1),
@@ -648,6 +669,14 @@ fn_plot_point_verif <- function(harp_verif_input,
             verif_II <- verif_II %>%
               harpPoint::filter_list(valid_dttm %in% exddtm)
             
+          }
+          # And something similar for valid_ymd
+          if (("valid_ymd" %in% names(verif_II[[1]])) &
+              (xgroup == "valid_ymd")) {
+            verif_II <- verif_II %>%
+              harpPoint::mutate_list(valid_ymd = harpCore::as_dttm(gsub("-| |:|UTC",
+                                                                        "",
+                                                                        valid_ymd)))
           }
 
           # Don't use attributes(stations) as this contains all stations, 
@@ -668,7 +697,7 @@ fn_plot_point_verif <- function(harp_verif_input,
             subtitle_str <- paste0(station," stations (",num_stations,") : ",cy_str)
           }
           # Add in lead times used for valid_dttm
-          if ((xgroup %in% c("valid_dttm")) & (!is.null(alta))) {
+          if ((xgroup %in% c("valid_dttm","valid_ymd")) & (!is.null(alta))) {
             subtitle_str <- paste0(subtitle_str,": +",lt_used_fig)
           }
 
@@ -692,7 +721,7 @@ fn_plot_point_verif <- function(harp_verif_input,
                 filter_col  <- "lead_time"
                 verif_III   <- verif_II %>%
                   harpPoint::filter_list(valid_hour == "All",
-                                         valid_dttm == "All")
+                                         !!sym(valid_dttm_col) == "All")
               } else if (xgroup == "lead_time") {
                 loop_values <- threshold_vals
                 filter_col  <- "threshold_val"
@@ -700,7 +729,7 @@ fn_plot_point_verif <- function(harp_verif_input,
                 verif_III   <- harpPoint::filter_list(verif_II,
                                                       lead_time != "All",
                                                       valid_hour == "All",
-                                                      valid_dttm == "All") 
+                                                      !!sym(valid_dttm_col) == "All") 
               } 
               for (ii in loop_values) {
                 verif_IIII <- harpPoint::filter_list(verif_III,
@@ -804,6 +833,12 @@ fn_plot_point_verif <- function(harp_verif_input,
                                                            valid_dttm == "All")
                     }
                   }
+                  if ("valid_ymd" %in% names(verif_III[[c_tstr]])) {
+                    if ("All" %in% unique(verif_III[[c_tstr]][["valid_ymd"]])){
+                      verif_III[[c_tstr]] <- dplyr::filter(verif_III[[c_tstr]],
+                                                           valid_ymd == "All")
+                    }
+                  }
                 }
               }
               
@@ -852,7 +887,7 @@ fn_plot_point_verif <- function(harp_verif_input,
         
             verif_III <- harpPoint::filter_list(verif_II,
                                                 valid_hour == "All",
-                                                valid_dttm == "All")
+                                                !!sym(valid_dttm_col) == "All")
             
             if (c_ind) {
               cat("Plotting for xgroup:",xgroup,"\n")
@@ -1209,7 +1244,7 @@ fn_plot_point_verif <- function(harp_verif_input,
                 c_ind <- FALSE
               }
               
-              vhours <- base::intersect(allvalidh,c("00","12"))
+              vhours <- base::intersect(allvalidh,pr_validh)
 
               if (length(vhours) > 0) {
               for (vh in vhours) {

--- a/visualization/visapp/app.R
+++ b/visualization/visapp/app.R
@@ -307,6 +307,9 @@ all_ens_ssum_scores      <- list("Spread Skill"              = paste0("rmse",sco
                                  "Spread Skill Ratio"        = "spread_skill_ratio-lt",
                                  "CRPS"                      = "crps-lt",
                                  "Spread"                    = "spread-lt",
+                                 "RMSE"                      = "rmse-lt",
+                                 "MAE"                       = "mae-lt",
+                                 "STDV"                      = "stde-lt",
                                  "Fair CRPS"                 = "fair_crps-lt",
                                  "Member Bias"               = "mbrbias-lt",
                                  "Member RMSE"               = "mbrrmse-lt",
@@ -320,20 +323,27 @@ all_ens_ssum_scores      <- list("Spread Skill"              = paste0("rmse",sco
                                  "Mean Frequency Dist"       = "freqdist-NA",
                                  "Mean Frequency Hist"       = "freqhist-cls",
                                  "Mean Frequency Bias"       = "freq_bias-cls",
-                                 "Mean Scatterplot"          = "scatterplot-NA"
+                                 "Mean Scatterplot"          = "scatterplot-NA",
+                                 "Mean Q-Q"                  = "quant-qobs",
+                                 "Mean Q-Q diff"             = "qdiff-qobs"
 )
 
 # Ensemble control member
 all_ensctrl_ssum_scores  <- list("Bias RMSE"            = paste0("bias",score_sep,"rmse-lt"),
                                  "Bias STDV"            = paste0("bias",score_sep,"stde-lt"),
                                  "Bias MAE"             = paste0("bias",score_sep,"mae-lt"),
+                                 "RMSE"                 = "rmse-lt",
+                                 "MAE"                  = "mae-lt",
+                                 "STDV"                 = "stde-lt",
                                  "DailyVar"             = "dailyvar-vh",
                                  "Forecast Timeseries"  = "timeseries-vd",
                                  "Bias STDV Timeseries" = paste0("bias",score_sep,"stde-vd"),
                                  "Frequency Dist"       = "freqdist-NA",
                                  "Frequency Hist"       = "freqhist-cls",
                                  "Frequency Bias"       = "freq_bias-cls",
-                                 "Scatterplot"          = "scatterplot-NA"
+                                 "Scatterplot"          = "scatterplot-NA",
+                                 "Q-Q"                  = "quant-qobs",
+                                 "Q-Q diff"             = "qdiff-qobs"
 )
 all_ensctrl_ssum_scores  <- lapply(all_ensctrl_ssum_scores,function(x) paste0("ctrl",x))
 
@@ -341,6 +351,9 @@ all_ensctrl_ssum_scores  <- lapply(all_ensctrl_ssum_scores,function(x) paste0("c
 all_det_ssum_scores      <- list("Bias RMSE"            = paste0("bias",score_sep,"rmse-lt"),
                                  "Bias STDV"            = paste0("bias",score_sep,"stde-lt"),
                                  "Bias MAE"             = paste0("bias",score_sep,"mae-lt"),
+                                 "RMSE"                 = "rmse-lt",
+                                 "MAE"                  = "mae-lt",
+                                 "STDV"                 = "stde-lt",
                                  "DailyVar"             = "dailyvar-vh",
                                  "Forecast Timeseries"  = "timeseries-vd",
                                  "Bias STDV Timeseries" = paste0("bias",score_sep,"stde-vd"),
@@ -348,7 +361,11 @@ all_det_ssum_scores      <- list("Bias RMSE"            = paste0("bias",score_se
                                  "Frequency Hist"       = "freqhist-cls",
                                  "Frequency Heatmap"    = "2dfreqhist-cls",
                                  "Frequency Bias"       = "freq_bias-cls",
-                                 "Scatterplot"          = "scatterplot-NA"
+                                 "Scatterplot"          = "scatterplot-NA",
+                                 "Q-Q"                  = "quant-qobs",
+                                 "Q-Q diff"             = "qdiff-qobs",
+                                 "NFA"                  = "nfa-lt",
+                                 "MSSS"                 = "msss-lt"
 )
 # Add SCAT scores
 all_scat_ssum_scores_2b  <- list("HY-2B Bias RMSE"      = paste0("SCAThy2bbias",score_sep,"rmse-lt"),
@@ -417,13 +434,24 @@ all_det_map_scores       <- c(all_det_map_scores,all_scat_map_scores_2b,
 
 # Upper air scores
 # Leadtime pressure levels
-all_ens_pl_scores        <- list("Mean Bias RMSE" = paste0("mean_bias",score_sep,"rmse"))
+all_ens_pl_scores        <- list("Mean Bias RMSE" = paste0("mean_bias",score_sep,"rmse"),
+                                 "RMSE"           = "rmse",
+                                 "MAE"            = "mae",
+                                 "STDV"           = "stde")
 all_ens_pl_scores        <- lapply(all_ens_pl_scores,function(x) paste0(x,"-lt"))
 
-all_ensctrl_pl_scores    <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"))
+all_ensctrl_pl_scores    <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"),
+                                 "RMSE"      = "rmse",
+                                 "MAE"       = "mae",
+                                 "STDV"      = "stde")
 all_ensctrl_pl_scores    <- lapply(all_ensctrl_pl_scores,function(x) paste0("ctrl",x,"-lt"))
 
-all_det_pl_scores        <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"))
+all_det_pl_scores        <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"),
+                                 "RMSE"      = "rmse",
+                                 "MAE"       = "mae",
+                                 "STDV"      = "stde",
+                                 "NFA"       = "nfa",
+                                 "MSSS"      = "msss")
 all_det_pl_scores        <- lapply(all_det_pl_scores,function(x) paste0(x,"-lt"))
 # Add obsfreq
 add_det_pl_scores        <- list("Obs. Frequency" = "obsfreq-mp")
@@ -436,17 +464,26 @@ all_ens_prof_scores      <- list("Mean Bias RMSE" = paste0("mean_bias",score_sep
                                  "Spread Skill"   = paste0("rmse",score_sep,"spread"),
                                  "CRPS"           = "crps",
                                  "Spread"         = "spread",
+                                 "RMSE"           = "rmse",
+                                 "MAE"            = "mae",
+                                 "STDV"           = "stde",
                                  "Fair CRPS"      = "fair_crps")
 all_ens_prof_scores      <- lapply(all_ens_prof_scores,function(x) paste0(x,"-pr"))
 
 # Ensemble control member
 all_ensctrl_prof_scores  <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"),
-                                 "Bias STDV" = paste0("bias",score_sep,"stde"))
+                                 "Bias STDV" = paste0("bias",score_sep,"stde"),
+                                 "RMSE"      = "rmse",
+                                 "MAE"       = "mae",
+                                 "STDV"      = "stde")
 all_ensctrl_prof_scores  <- lapply(all_ensctrl_prof_scores,function(x) paste0("ctrl",x,"-pr"))
 
 # Deterministic experiment 
 all_det_prof_scores      <- list("Bias RMSE" = paste0("bias",score_sep,"rmse"),
-                                 "Bias STDV" = paste0("bias",score_sep,"stde"))
+                                 "Bias STDV" = paste0("bias",score_sep,"stde"),
+                                 "RMSE"      = "rmse",
+                                 "MAE"       = "mae",
+                                 "STDV"      = "stde")
 all_det_prof_scores      <- lapply(all_det_prof_scores,function(x) paste0(x,"-pr"))
 # Add UAC scores
 all_det_prof_UACscores   <- list("Drift corrected Bias RMSE" = paste0("UACbias",score_sep,"rmse"),
@@ -464,6 +501,8 @@ all_det_prof_scores      <- c(all_det_prof_scores,all_lhmaps_ssum_scores)
 # Ensemble score diffs
 all_ens_sdiffs_scores <- list("Mean Bias"    = "mean_bias-lt",
                               "RMSE"         = "rmse-lt",
+                              "MAE"          = "mae-lt",
+                              "STDV"         = "stde-lt",
                               "Spread"       = "spread-lt",
                               "CRPS"         = "crps-lt",
                               "Fair CRPS"    = "fair_crps-lt")
@@ -1331,13 +1370,13 @@ server <- function(input, output, session) {
       switch(input$surfacetype,
              "Summary" = "Threshold",
              "Skill"   = "Threshold",
-             "Map"     = "Threshold",
+             "Map"     = "Lead time",
              "Signif"  = "Ref model")
     } else if (input$vartype == ua_tab_name){
       switch(input$temptype,
              "Summary" = "Threshold",
              "Prof"    = "Threshold",
-             "Map"     = "Threshold",
+             "Map"     = "Lead time",
              "Signif"  = "Ref model")
     } else if (input$vartype == sc_tab_name){
       "Ref model"


### PR DESCRIPTION
This PR bring in the following as a result of MLWP verification work:

* Allow for merging configs from multiple files for easier use.
* Allow for more customised forecast scaling using "specific" and "rest".
* Add quantile-quantile plots.
* Add ability to read climatology and compute specific scores relative to this.
* Better handling of Pcp when reading a model as analysis.
* Switch from valid_dttm -> valid_ymd for timeseries when the period considered is long.
* Move scripting in point_verif to standalone functions for parameter parsing and scorecard plotting.
* Enable plotting of geolists when looking at map scores.
* Add many more recognised parameters to default breaks function.
* Add config file flag to skip quality control checks.


FYI @svianaj @ewhelan 